### PR TITLE
Use `gh` instead of a dedicated action for working with releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,26 +14,16 @@ jobs:
     name: Create Github Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
-          prerelease: false
-
-      - name: Output Release URL File
-        run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
-      - name: Save Release URL File for publish
-        uses: actions/upload-artifact@v4
-        with:
-          name: release_url
-          path: release_url.txt
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag" \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="$tag" \
+            --generate-notes \
+            --draft
 
   build_artifact:
     needs: [create_release]
@@ -43,18 +33,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: ubuntu-latest
-          #   arch: aarch64
           - os: ubuntu-latest
             arch: x86_64
           - os: macOS-13 # macOS-latest does something weird I don't understand
             arch: aarch64
-          # - os: macOS-13 # macOS-latest does something weird I don't understand
-          #   arch: x86_64
           - os: windows-latest
             arch: x86_64
-          # - os: windows-latest
-          #   arch: aarch64
 
     steps:
       - name: Check out code
@@ -107,12 +91,12 @@ jobs:
       - if: matrix.os == 'windows-latest'
         name: Set zip file path name on Windows
         run: |
-          echo "ZIP_PATH=./bin/gitlab-helper.zip" >> $env:GITHUB_ENV
+          echo "ZIP_PATH=./bin/gitlab-helper-${{ steps.tag.outputs.tag }}-${{ runner.os }}.zip" >> $env:GITHUB_ENV
 
       - if: matrix.os != 'windows-latest'
         name: Set zip file path name not on Windows
         run: |
-          echo "ZIP_PATH=./bin/gitlab-helper.zip" >> "$GITHUB_ENV"
+          echo "ZIP_PATH=./bin/gitlab-helper-${{ steps.tag.outputs.tag }}-${{ runner.os }}.zip" >> "$GITHUB_ENV"
 
       - if: matrix.os != 'windows-latest'
         name: Create zip file not on windows
@@ -124,29 +108,9 @@ jobs:
         run: |
           7z a ${{ env.ZIP_PATH }} ${{ env.BINARY_PATH }}
 
-      - name: Load Release URL File from release job
-        uses: actions/download-artifact@v4
-        with:
-          name: release_url
-          path: release_url
-
-      - if: matrix.os == 'windows-latest'
-        name: Get Release File Name & Upload URL on Widows
-        run: |
-          echo "upload_url=$(cat release_url/release_url.txt)" >> $env:GITHUB_ENV
-
-      - if: matrix.os != 'windows-latest'
-        name: Get Release File Name & Upload URL not on Widows
-        run: |
-          echo "upload_url=$(cat release_url/release_url.txt)" >> $GITHUB_ENV
-
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.upload_url }}
-          asset_path: ${{ env.ZIP_PATH }}
-          asset_name: gitlab-helper-${{ steps.tag.outputs.tag }}-${{ runner.os }}.zip
-          asset_content_type: application/zip
+        run: |
+          gh release upload "${{ github.ref_name }}" "${{ env.ZIP_PATH }}#${{ runner.os }}.zip" --repo="$GITHUB_REPOSITORY"


### PR DESCRIPTION
Creation of new draft releases and uploading release artifacts is now done using the GitHub CLI instead of some action.
The previous, official action is deprecated and instead of choosing an action by someone from the internet, it feels better to use the official CLI tool that's installed on the runners already.

Closes #16