### PR TITLE
Introduce an argument to the meta listing to specify the scope

### DIFF
--- a/src/Config/Optparse.hs
+++ b/src/Config/Optparse.hs
@@ -62,8 +62,7 @@ commandParser =
       [ command "version" (info (pure Version) (progDesc "print program version")),
         command "show-branches" (info (pure ShowBranches) (progDesc "show branches")),
         command "show-projects" (info (pure ShowProjects) (progDesc "show projects")),
-        command "list-all-projects-meta" (info (pure ListAllProjectsMeta) (progDesc "list all the projects for all groups that are visible for the provided API token in (almost) meta compatible JSON format")),
-        command "list-projects-meta" (info (pure ListProjectsMeta) (progDesc "list the projects for the given group in (almost) meta compatible JSON format")),
+        command "list-projects-meta" (info (ListProjectsMeta <$> metaScopeParser) (progDesc "list the projects in (almost) meta compatible JSON format")),
         command "enable-source-branch-deletion" (info (EnableSourceBranchDeletionAfterMerge <$> executionParser) (progDesc "enable source branch deletion after merge for all projects")),
         command "enable-all-discussions-must-be-resolved-for-merge-requirement" (info (EnableAllDiscussionsMustBeResolvedForMergeRequirement <$> executionParser) (progDesc "enable the requirement that all discussions must be resolved for an MR to be merged for all projects")),
         command "enable-successful-pipeline-for-merge-requirement" (info (EnableSuccessfulPipelineForMergeRequirement <$> executionParser) (progDesc "enable the requirement that there must be a successful pipeline for an MR to be merged for all projects. CAUTION: Use with care, might not do what you want in projects without pipelines")),
@@ -103,6 +102,14 @@ mergeRequestUpdateCommandParser =
     mergeCiOptionParser :: Parser MergeCiOption
     mergeCiOptionParser =
       flag PipelineMustSucceed SkipCi (long "skip-ci" <> help "don't enforce that a merge request requires a successful pipeline to be merged (also helpful for projects that don't have pipelines on non-default branches)")
+
+metaScopeParser :: Parser MetaScope
+metaScopeParser = argument (eitherReader scopeParser) (metavar "SCOPE" <> showDefault <> value MetaScopeGroup <> help "Scope for the list of projects. Possible values are \"group\" (which is the default and includes all the projects for the current group), or \"all\" (which includes all the projects that are visible with the provided API Token)")
+  where
+    scopeParser :: String -> Either String MetaScope
+    scopeParser "all" = Right MetaScopeAll
+    scopeParser "group" = Right MetaScopeGroup
+    scopeParser s = Left $ "\"" <> s <> "\" is not a valid scope"
 
 executionParser :: Parser Execution
 executionParser =

--- a/src/Config/Types.hs
+++ b/src/Config/Types.hs
@@ -8,6 +8,7 @@ module Config.Types
     PartialConfig (..),
     Command (..),
     MergeRequestUpdateAction (..),
+    MetaScope (..),
     MergeCiOption (..),
     AuthorIs (..),
     SearchTerm (..),
@@ -58,8 +59,7 @@ data Command
   | ShowBranches
   | EnableSourceBranchDeletionAfterMerge Execution
   | ShowProjects
-  | ListAllProjectsMeta
-  | ListProjectsMeta
+  | ListProjectsMeta MetaScope
   | ShowSchedules
   | ShowMergeRequests MergeStatusRecheck
   | EnableAllDiscussionsMustBeResolvedForMergeRequirement Execution
@@ -70,6 +70,8 @@ data Command
   deriving stock (Show)
 
 data Execution = DryRun | Execute deriving stock (Eq, Show)
+
+data MetaScope = MetaScopeGroup | MetaScopeAll deriving stock (Eq, Show)
 
 data MergeRequestUpdateAction = List | Rebase | Merge MergeCiOption | SetToDraft | MarkAsReady deriving stock (Show)
 

--- a/src/Program.hs
+++ b/src/Program.hs
@@ -26,8 +26,7 @@ run = do
         ShowBranches -> showBranchesForGroup
         (EnableSourceBranchDeletionAfterMerge execution) -> enableSourceBranchDeletionAfterMerge execution
         ShowProjects -> showProjectsForGroup
-        ListAllProjectsMeta -> listAllProjectsMeta
-        ListProjectsMeta -> listProjectsMetaForGroup
+        ListProjectsMeta scope -> listProjectsMeta scope
         ShowSchedules -> showSchedulesForGroup
         (ShowMergeRequests recheckMergeStatus) -> showMergeRequests recheckMergeStatus
         (EnableAllDiscussionsMustBeResolvedForMergeRequirement execution) -> enableAllDiscussionsResolvedForMergeRequirement execution

--- a/src/Projects.hs
+++ b/src/Projects.hs
@@ -8,13 +8,12 @@
 {-# LANGUAGE TupleSections #-}
 
 module Projects
-  ( listAllProjectsMeta,
+  ( listProjectsMeta,
     showProjectsForGroup,
     enableSourceBranchDeletionAfterMerge,
     enableSuccessfulPipelineForMergeRequirement,
     enableAllDiscussionsResolvedForMergeRequirement,
     setMergeMethodToFastForward,
-    listProjectsMetaForGroup,
     countDeployments,
   )
 where
@@ -32,6 +31,10 @@ import Gitlab.Group (Group)
 import Gitlab.Lib (EnabledDisabled (..), Id (..), Name (..), Ref (..))
 import Gitlab.Project
 import Relude hiding (pi)
+
+listProjectsMeta :: MetaScope -> App ()
+listProjectsMeta MetaScopeAll = listAllProjectsMeta
+listProjectsMeta MetaScopeGroup = listProjectsMetaForGroup
 
 listAllProjectsMeta :: App ()
 listAllProjectsMeta = fetch >>= bitraverse_ (write . show) writeMetaFormat

--- a/test_resources/help-text.txt
+++ b/test_resources/help-text.txt
@@ -21,11 +21,8 @@ Available commands:
   version                  print program version
   show-branches            show branches
   show-projects            show projects
-  list-all-projects-meta   list all the projects for all groups that are visible
-                           for the provided API token in (almost) meta
-                           compatible JSON format
-  list-projects-meta       list the projects for the given group in (almost)
-                           meta compatible JSON format
+  list-projects-meta       list the projects in (almost) meta compatible JSON
+                           format
   enable-source-branch-deletion
                            enable source branch deletion after merge for all
                            projects


### PR DESCRIPTION
This replaces the two commands for the different scopes by one command with an argument. This should help in making the overall API surface a bit cleaner.

Refers to #26