### PR TITLE
Queued processing

### DIFF
--- a/gitlab-helper.cabal
+++ b/gitlab-helper.cabal
@@ -49,7 +49,9 @@ library
     , colonnade
     , colourista
     , containers
+    , exceptions
     , gitlab-api-http-client-mtl
+    , gitlab-api-http-client-queued-mtl
     , gitlab-api-types
     , http-conduit
     , http-types
@@ -61,6 +63,7 @@ library
     , scientific
     , text
     , time
+    , unliftio-core
   default-language: Haskell2010
 
 executable gitlab-helper

--- a/package.yaml
+++ b/package.yaml
@@ -48,9 +48,11 @@ library:
     - colonnade
     - colourista
     - containers
+    - exceptions
     - http-conduit
     - http-types
     - gitlab-api-http-client-mtl
+    - gitlab-api-http-client-queued-mtl
     - gitlab-api-types
     - network-uri
     - opt-env-conf
@@ -60,6 +62,7 @@ library:
     - scientific
     - text
     - time
+    - unliftio-core
 
 executables:
   gitlab-helper:

--- a/src/App.hs
+++ b/src/App.hs
@@ -6,6 +6,8 @@
 module App (App (..)) where
 
 import Config
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Gitlab.Client.MTL (HasApiToken (..), HasBaseUrl (..), HasUserAgent (..))
 import Relude
 
@@ -15,7 +17,11 @@ newtype App a = App {unApp :: ReaderT Config IO a}
       Applicative,
       Monad,
       MonadIO,
-      MonadReader Config
+      MonadReader Config,
+      MonadThrow,
+      MonadCatch,
+      MonadMask,
+      MonadUnliftIO
     )
 
 instance HasApiToken App where

--- a/src/Schedules.hs
+++ b/src/Schedules.hs
@@ -19,7 +19,7 @@ import App (App)
 import Colourista.Pure
 import Config (Config (..), WithArchivedProjects (SkipArchivedProjects))
 import Effects
-import Gitlab.Client.MTL (UpdateError)
+import Gitlab.Client.Queue.MTL
 import Gitlab.Lib (Name (..))
 import Gitlab.Project
 import Relude
@@ -29,12 +29,11 @@ showSchedulesForGroup = do
   gId <- asks groupId
   write "=================================================="
   write $ "Listing the projects' schedules for Group " <> show gId
-  getProjectsForGroup SkipArchivedProjects >>= \case
+  processProjectsForGroupQueued SkipArchivedProjects (fmap (Right . Result) . getSchedulesForProject) >>= \case
     Left err -> write $ show err
-    Right projects -> do
-      results <- traverse getSchedulesForProject (sortOn (getName . projectName) projects)
-      traverse_ printResults results
-      writeSummary results
+    Right res -> do
+      traverse_ printResults (sortOn (getName . projectName . fst) res)
+      writeSummary res
 
 getSchedulesForProject :: Project -> App (Project, Either UpdateError [Schedule])
 getSchedulesForProject p = (p,) <$> getSchedules (projectId p)

--- a/src/UpdateMergeRequests.hs
+++ b/src/UpdateMergeRequests.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 module UpdateMergeRequests
   ( updateMergeRequests,
@@ -10,6 +10,7 @@ import App (App)
 import Config
 import Data.Text (isInfixOf, strip, stripPrefix, toLower)
 import Effects
+import Gitlab.Client.Queue.MTL (ProcessResult (..), UpdateError)
 import Gitlab.Lib (Id)
 import Gitlab.MergeRequest
 import Gitlab.Project (Project)
@@ -27,27 +28,36 @@ updateMergeRequests _ (Merge _) _ Nothing _ Execute =
   write "I don't think you want to blindly merge all merge requests for this group. Consider adding a filter. Exiting now."
 updateMergeRequests projectExcludes action authorIs maybeSearchTerms recheckMergeStatus execute = do
   let searchTerm' = either id (\(SearchTermTitle s) -> SearchTerm s) <$> maybeSearchTerms
-  getOpenMergeRequestsForGroup authorIs searchTerm' recheckMergeStatus >>= \case
-    Left err -> write $ show err
-    Right [] -> write "no MRs to process"
-    Right allMergeRequests -> do
-      let titleFilter mr = case maybeSearchTerms of
-            Just (Right (SearchTermTitle s)) -> toLower (toText s) `isInfixOf` toLower (mergeRequestTitle mr)
-            _ -> True
-          filteredMergeRequests = filter (\mr -> titleFilter mr && mergeRequestProjectId mr `notElem` projectExcludes) allMergeRequests
-      case filteredMergeRequests of
-        [] -> write "no MRs to process after applying filters"
-        mergeRequests -> forM_ mergeRequests $ \mr -> do
-          write $ "processing MR #" <> show (mergeRequestIid mr) <> " in Project #" <> show (mergeRequestProjectId mr) <> " with state " <> show (mergeRequestDetailedMergeStatus mr) <> ": " <> mergeRequestTitle mr
-          res <- performAction mr
-          case res of
-            Left err -> write $ "failed to update merge request: " <> show err
-            Right _ -> pure ()
+  res <- getOpenMergeRequestsForGroupQueued authorIs searchTerm' recheckMergeStatus $ \mr -> do
+    if titleFilter mr && excludeFilter mr
+      then do
+        (txt, res) <- performAction mr
+        pure $ PrintLinesWithResult (mconcat (mrTextLine mr <> maybe [] (\t -> [" >> ", t]) txt) :| []) () <$ res
+      else pure $ Right Empty
+  case res of
+    Left err -> write $ "failed to update merge requests: " <> show err
+    Right [] -> write "no merge requests to process"
+    Right updates -> write $ show (length updates) <> " merge requests"
   where
+    mrTextLine mr =
+      [ "#",
+        show (mergeRequestIid mr),
+        " in Project #",
+        show (mergeRequestProjectId mr),
+        " with state ",
+        show (mergeRequestDetailedMergeStatus mr),
+        ": ",
+        mergeRequestTitle mr
+      ]
+    titleFilter mr = case maybeSearchTerms of
+      Just (Right (SearchTermTitle s)) -> toLower (toText s) `isInfixOf` toLower (mergeRequestTitle mr)
+      _ -> True
+    excludeFilter mr = mergeRequestProjectId mr `notElem` projectExcludes
+    performAction :: MergeRequest -> App (Maybe Text, Either UpdateError ())
     performAction mr =
       let pId = mergeRequestProjectId mr
        in case action of
-            List -> pure $ Right ()
+            List -> pure (Nothing, Right ())
             Rebase -> rebaseAction pId (mergeRequestIid mr)
             (Merge mergeCiOption) -> case detailedMergeStatusToDecision (mergeRequestDetailedMergeStatus mr) of
               MergeShouldWork -> mergeAction pId (mergeRequestIid mr) mergeCiOption
@@ -55,29 +65,29 @@ updateMergeRequests projectExcludes action authorIs maybeSearchTerms recheckMerg
               MergeWontWork -> mergeWontWorkAction (mergeRequestDetailedMergeStatus mr)
             SetToDraft ->
               if mergeRequestWip mr
-                then Right () <$ write "merge request is already in state \"Draft\""
+                then pure (Just "merge request is already in state \"Draft\"", Right ())
                 else setToDraftAction pId (mergeRequestIid mr) (mergeRequestTitle mr)
             MarkAsReady ->
               if mergeRequestWip mr
                 then markAsReadyAction pId (mergeRequestIid mr) (mergeRequestTitle mr)
-                else Right () <$ write "merge request is already marked as ready"
+                else pure (Just "merge request is already marked as ready", Right ())
 
     (rebaseAction, mergeAction, mergeAttemptAction, mergeWontWorkAction, setToDraftAction, markAsReadyAction) = case execute of
       Execute ->
-        ( rebaseMergeRequest,
-          mergeMergeRequest,
-          mergeMergeRequest,
-          \detailedStatus -> Right () <$ write ("The merge status is " <> show detailedStatus <> ", skipping the merge as it wouldn't succeed"),
-          \pId mrIid mrTitle -> setMergeRequestTitle pId mrIid ("Draft: " <> mrTitle),
-          \pId mrIid mrTitle -> setMergeRequestTitle pId mrIid (strip $ fromMaybe mrTitle (stripPrefix "Draft:" mrTitle))
+        ( \pId mId -> (Nothing,) <$> rebaseMergeRequest pId mId,
+          \pId mId mco -> (Nothing,) <$> mergeMergeRequest pId mId mco,
+          \pId mId mco -> (Nothing,) <$> mergeMergeRequest pId mId mco,
+          \detailedStatus -> pure (Just $ "The merge status is " <> show detailedStatus <> ", skipping the merge as it wouldn't succeed", Right ()),
+          \pId mrIid mrTitle -> (Nothing,) <$> setMergeRequestTitle pId mrIid ("Draft: " <> mrTitle),
+          \pId mrIid mrTitle -> (Nothing,) <$> setMergeRequestTitle pId mrIid (strip $ fromMaybe mrTitle (stripPrefix "Draft:" mrTitle))
         )
       DryRun ->
-        ( \_ _ -> Right () <$ write "dry run. skipping rebase",
-          \_ _ _ -> Right () <$ write "dry run. skipping merge",
-          \_ _ _ -> Right () <$ write "dry run. skipping merge attempt",
-          \detailedStatus -> Right () <$ write ("The merge status is " <> show detailedStatus <> ", skipping the merge as it wouldn't succeed"),
-          \_ _ _ -> Right () <$ write "dry run. skipping draft toggle",
-          \_ _ _ -> Right () <$ write "dry run. skipping draft toggle"
+        ( \_ _ -> pure (Just "dry run. skipping rebase", Right ()),
+          \_ _ _ -> pure (Just "dry run. skipping merge", Right ()),
+          \_ _ _ -> pure (Just "dry run. skipping merge attempt", Right ()),
+          \detailedStatus -> pure (Just $ "The merge status is " <> show detailedStatus <> ", skipping the merge as it wouldn't succeed", Right ()),
+          \_ _ _ -> pure (Just "dry run. skipping draft toggle", Right ()),
+          \_ _ _ -> pure (Just "dry run. skipping draft toggle", Right ())
         )
 
 -- | Depending on the merge status of a merge request, trying a merge may or may not make sense.

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,8 @@ extra-deps:
     subdirs:
       - gitlab-api-http-client
       - gitlab-api-http-client-mtl
+      - gitlab-api-http-client-queued
+      - gitlab-api-http-client-queued-mtl
       - gitlab-api-types
   - github: NorfairKing/opt-env-conf
     commit: de7ac850e960c28e5182810515a87fbe1d6daede

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -31,6 +31,32 @@ packages:
     subdir: gitlab-api-http-client-mtl
     url: https://github.com/L7R7/gitlab-api/archive/93b751da90c6141f960e61ce3bc2f31da43e564a.tar.gz
 - completed:
+    name: gitlab-api-http-client-queued
+    pantry-tree:
+      sha256: 19878699f2dc1ad379e30923adba5a8a0bc61e32e1bb2a94c2ebf90faf76a466
+      size: 200
+    sha256: 3650c0d7fff8a08330a56387925416e62429601ed7519b0ddfebc7f2bbf06ba3
+    size: 23974
+    subdir: gitlab-api-http-client-queued
+    url: https://github.com/L7R7/gitlab-api/archive/93b751da90c6141f960e61ce3bc2f31da43e564a.tar.gz
+    version: 0.0.0.1
+  original:
+    subdir: gitlab-api-http-client-queued
+    url: https://github.com/L7R7/gitlab-api/archive/93b751da90c6141f960e61ce3bc2f31da43e564a.tar.gz
+- completed:
+    name: gitlab-api-http-client-queued-mtl
+    pantry-tree:
+      sha256: 4a9a6a245b4f9fb64ae3974a9056d205675f4f71ce4b8c0256305bc65f1a89f9
+      size: 208
+    sha256: 3650c0d7fff8a08330a56387925416e62429601ed7519b0ddfebc7f2bbf06ba3
+    size: 23974
+    subdir: gitlab-api-http-client-queued-mtl
+    url: https://github.com/L7R7/gitlab-api/archive/93b751da90c6141f960e61ce3bc2f31da43e564a.tar.gz
+    version: 0.0.0.1
+  original:
+    subdir: gitlab-api-http-client-queued-mtl
+    url: https://github.com/L7R7/gitlab-api/archive/93b751da90c6141f960e61ce3bc2f31da43e564a.tar.gz
+- completed:
     name: gitlab-api-types
     pantry-tree:
       sha256: e18fb21d7a62f7752d5f0b0f8ad790bcc057b26aa5b50bb994cc707855fc9bbd


### PR DESCRIPTION
This brings benefits for all cases where paginated resources are consumed, especially when there's a lot of elements. The `gitlab-api` package now provides a manager-worker-pattern, where the paginated resource is crawled and at the same time several workers can process the elements concurrently.
For example, when working with merge requests, the user doesn't have to wait until all merge requests have been loaded. This means faster feedback cycles and a better user experience.